### PR TITLE
SAF-3297: Cannot add new user

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "net",
+  "name": "idelic-safety-net",
   "version": "1.0.15",
   "lockfileVersion": 1,
   "requires": true,
@@ -1894,7 +1894,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2309,7 +2310,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2365,6 +2367,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2408,12 +2411,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/error.ts
+++ b/src/error.ts
@@ -13,7 +13,7 @@ export default class NetError<T> extends Error {
     if (typeof request.response === 'string') {
       return request.response;
     }
-    if (typeof request.response.message === 'string') {
+    if (request.response && typeof request.response.message === 'string') {
       return request.response.message;
     }
     switch (Math.floor(request.status / 100)) {

--- a/src/error.ts
+++ b/src/error.ts
@@ -10,6 +10,12 @@ export default class NetError<T> extends Error {
   }
 
   static createErrorMessage(request: XMLHttpRequest): string {
+    if (typeof request.response === 'string') {
+      return request.response;
+    }
+    if (typeof request.response.message === 'string') {
+      return request.response.message;
+    }
     switch (Math.floor(request.status / 100)) {
       case 4:
         return 'Error performing request. Please double check your input and try again.';


### PR DESCRIPTION
This PR changes the `createErrorMessage` login in NetError to preserve the original message, and only use a default if no message is present.