### PR TITLE
SAF-3890: Updating error message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1894,7 +1894,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1915,12 +1916,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1935,17 +1938,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2062,7 +2068,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2074,6 +2081,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2088,6 +2096,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2095,12 +2104,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2119,6 +2130,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2199,7 +2211,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2211,6 +2224,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2296,7 +2310,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2332,6 +2347,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2351,6 +2367,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2394,12 +2411,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/error.ts
+++ b/src/error.ts
@@ -16,7 +16,7 @@ export default class NetError<E> extends Error {
       case 5:
         return 'Unexpected server error. Please try again.';
       case 0:
-        if (request.readyState == 0) {
+        if (request.readyState == XMLHttpRequest.UNSENT) {
           return 'Request was cancelled.';
         } else {
           return 'There is a connection issue.  Please check your internet connection and try again.';

--- a/src/request.ts
+++ b/src/request.ts
@@ -33,6 +33,15 @@ export function request<R, T, E = any>(
   request.withCredentials = true;
   request.responseType = options.responseType || 'json';
 
+  request.onreadystatechange = function() {
+    if (this.readyState === XMLHttpRequest.HEADERS_RECEIVED) {
+      const contentType = this.getResponseHeader('Content-Type') || '';
+      if (contentType.includes('application/json')) {
+        this.responseType = 'json';
+      }
+    }
+  };
+
   const cancellable = addEventListeners<T, E>(request, options);
 
   const body: any =


### PR DESCRIPTION
This PR sets `responseType` after receiving response headers to prevent incorrect response type conversion by `XMLHttpRequest`. This is so a request that expects a non-`JSON` response can accept a `JSON` error object.